### PR TITLE
Add helmet to express server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "dotenv": "^10.0.0",
         "express": "^4.17.1",
+        "helmet": "^4.6.0",
         "mongodb": "^4.0.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -2906,6 +2907,14 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
+      "integrity": "sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/history": {
@@ -8747,6 +8756,11 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
+    },
+    "helmet": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
+      "integrity": "sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg=="
     },
     "history": {
       "version": "4.10.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
+    "helmet": "^4.6.0",
     "mongodb": "^4.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ dotenv.config();
 import express from 'express';
 import { connectToMongoDb } from './lib/db';
 import router from './lib/router';
+import helmet from 'helmet';
 
 const { PORT, MONGODB_URI } = process.env;
 
@@ -16,6 +17,9 @@ if (typeof MONGODB_URI !== 'string') {
 }
 
 const app = express();
+
+// Collection of smaller middleware that set security-related HTTP response headers
+app.use(helmet());
 
 // Middleware that parses json and looks at requests where the Content-Type header matches the type option.
 app.use(express.json());


### PR DESCRIPTION
Via helmet we set security-related HTTP response headers. In most cases helmet offer us a basic protection against security vulnerabilities.

**Response header before helmet**
```
HTTP/1.1 200 OK
X-Powered-By: Express
Content-Type: application/json; charset=utf-8
Content-Length: 132
ETag: W/"84-dWkg4d6zCZ+gycnJ+1xmTbxKIGo"
Date: Thu, 22 Jul 2021 08:39:50 GMT
Connection: close
```

**Response header with helmet**
```
HTTP/1.1 200 OK
Content-Security-Policy: default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests
X-DNS-Prefetch-Control: off
Expect-CT: max-age=0
X-Frame-Options: SAMEORIGIN
Strict-Transport-Security: max-age=15552000; includeSubDomains
X-Download-Options: noopen
X-Content-Type-Options: nosniff
X-Permitted-Cross-Domain-Policies: none
Referrer-Policy: no-referrer
X-XSS-Protection: 0
Content-Type: application/json; charset=utf-8
Content-Length: 132
ETag: W/"84-pBUOSPCvfcpMKNfsumSOjfTcvog"
Date: Thu, 22 Jul 2021 08:37:36 GMT
Connection: close
```

**Sources**
npm: https://www.npmjs.com/package/helmet
github: https://github.com/helmetjs/helmet