### PR TITLE
🔧 Use local debugger

### DIFF
--- a/dist/overwolf/manifest.json
+++ b/dist/overwolf/manifest.json
@@ -19,10 +19,12 @@
     "windows": {
       "background": {
         "file": "build/background.html",
+        "debug_url": "http://localhost:3000/background.html",
         "is_background_page": true
       },
       "desktop": {
         "file": "build/index.html",
+        "debug_url": "http://localhost:3000/index.html",
         "desktop_only": true,
         "native_window": true,
         "resizable": true,
@@ -40,6 +42,7 @@
       },
       "development": {
         "file": "build/development.html",
+        "debug_url": "http://localhost:3000/development.html",
         "size": {
           "width": 1212,
           "height": 699


### PR DESCRIPTION
The local debugger allows us to serve code from a development server:
https://overwolf.github.io/docs/start/using-dev-tools#use-local-debugger-with-debug_url-flag

There is a known issue which prevents local file access, which is required for our video capturing. If you need this feature, please remove the `debug_url` temporary.
https://discuss.overwolf.com/t/no-file-system-access-with-debug-url-and-reload-issue/1911