### PR TITLE
🚚 Move types to shared place

### DIFF
--- a/src/lib/matches.ts
+++ b/src/lib/matches.ts
@@ -1,20 +1,7 @@
-import { Collection, Document, Filter, ObjectId } from 'mongodb';
+import { Collection, Document, Filter } from 'mongodb';
 import { getCollection, getDb } from './db';
 import { ParsedQs } from 'qs';
-
-export type MatchHighlight = {
-  timestamp: number;
-  type: string;
-  videoSrc: string;
-};
-
-export type Match = {
-  _id?: ObjectId;
-  gameId: number;
-  username: string;
-  createdAt: Date;
-  highlights: MatchHighlight[];
-};
+import { Match } from '../types';
 
 export function getMatchesCollection(): Collection<Match> {
   return getCollection<Match>('matches');

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -1,11 +1,7 @@
 import { MongoServerError, ObjectId } from 'mongodb';
 import express from 'express';
-import {
-  getMatchesCollection,
-  MatchHighlight,
-  Match,
-  createMatchesQuery,
-} from './matches';
+import { getMatchesCollection, createMatchesQuery } from './matches';
+import type { Match, MatchHighlight } from '../types';
 
 const router = express.Router();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,16 @@
+// Types shared by client and server
+import type { ObjectId } from 'mongodb';
+
+export type MatchHighlight = {
+  timestamp: number;
+  type: string;
+  videoSrc: string;
+};
+
+export type Match = {
+  _id?: ObjectId;
+  gameId: number;
+  username: string;
+  createdAt: Date;
+  highlights: MatchHighlight[];
+};


### PR DESCRIPTION
We can access the same type on client and server if we outsource them to a shared place.
If we would import the types on the client without the change, it would fail due to other server side imports like `mongodb`.
This allows us to create components which access the same type like on the server.