### PR TITLE
💥 Modify and rename the type in a match highlight

### DIFF
--- a/samples.http
+++ b/samples.http
@@ -36,7 +36,7 @@ Content-Type: application/json
 
 {
     "timestamp": 360,
-    "type": "kill",
+    "type": ["kill"],
     "videoSrc": "https://cloudinary.com/video/1"
 }
 
@@ -46,7 +46,7 @@ Content-Type: application/json
 
 {
     "timestamp": 450,
-    "type": "kill",
+    "type": ["kill"],
     "videoSrc": "https://cloudinary.com/video/1"
 }
 
@@ -56,7 +56,7 @@ Content-Type: application/json
 
 {
     "timestamp": 450,
-    "type": "kill",
+    "type": ["kill"],
     "videoSrc": "https://cloudinary.com/video/1"
 }
 

--- a/samples.http
+++ b/samples.http
@@ -36,7 +36,7 @@ Content-Type: application/json
 
 {
     "timestamp": 360,
-    "type": ["kill"],
+    "events": ["kill"],
     "videoSrc": "https://cloudinary.com/video/1"
 }
 
@@ -46,7 +46,7 @@ Content-Type: application/json
 
 {
     "timestamp": 450,
-    "type": ["kill"],
+    "events": ["kill"],
     "videoSrc": "https://cloudinary.com/video/1"
 }
 
@@ -56,7 +56,7 @@ Content-Type: application/json
 
 {
     "timestamp": 450,
-    "type": ["kill"],
+    "events": ["kill"],
     "videoSrc": "https://cloudinary.com/video/1"
 }
 

--- a/src/app/components/MatchDetails/MatchDetails.examples.tsx
+++ b/src/app/components/MatchDetails/MatchDetails.examples.tsx
@@ -10,12 +10,12 @@ export const MatchDetailsLukas: Example = () => (
       highlights: [
         {
           timestamp: 10,
-          type: ['kill', 'assist'],
+          events: ['kill', 'assist'],
           videoSrc: 'https://example.com/video.mp4',
         },
         {
           timestamp: 30,
-          type: ['death'],
+          events: ['death'],
           videoSrc: 'https://example.com/video.mp4',
         },
       ],

--- a/src/app/components/MatchDetails/MatchDetails.examples.tsx
+++ b/src/app/components/MatchDetails/MatchDetails.examples.tsx
@@ -10,12 +10,12 @@ export const MatchDetailsLukas: Example = () => (
       highlights: [
         {
           timestamp: 10,
-          type: 'kill',
+          type: ['kill', 'assist'],
           videoSrc: 'https://example.com/video.mp4',
         },
         {
           timestamp: 30,
-          type: 'death',
+          type: ['death'],
           videoSrc: 'https://example.com/video.mp4',
         },
       ],

--- a/src/app/components/MatchDetails/MatchDetails.tsx
+++ b/src/app/components/MatchDetails/MatchDetails.tsx
@@ -18,7 +18,7 @@ function MatchDetails({ match }: MatchDetailsProps): JSX.Element {
       {match.highlights.map((highlight) => (
         <article key={highlight.timestamp} className={classes.highlight}>
           <VideoHighlight src={highlight.videoSrc} />
-          <p>{highlight.type}</p>
+          <p>{highlight.type.join(', ')}</p>
           <p>{highlight.timestamp}</p>
         </article>
       ))}

--- a/src/app/components/MatchDetails/MatchDetails.tsx
+++ b/src/app/components/MatchDetails/MatchDetails.tsx
@@ -18,7 +18,7 @@ function MatchDetails({ match }: MatchDetailsProps): JSX.Element {
       {match.highlights.map((highlight) => (
         <article key={highlight.timestamp} className={classes.highlight}>
           <VideoHighlight src={highlight.videoSrc} />
-          <p>{highlight.type.join(', ')}</p>
+          <p>{highlight.events.join(', ')}</p>
           <p>{highlight.timestamp}</p>
         </article>
       ))}

--- a/src/app/components/MatchItem/MatchItem.examples.tsx
+++ b/src/app/components/MatchItem/MatchItem.examples.tsx
@@ -19,7 +19,7 @@ export const MatchItems: Example = () => (
         highlights: [
           {
             timestamp: 10,
-            type: 'kill',
+            type: ['kill'],
             videoSrc: 'https://example.com/video.mp4',
           },
         ],

--- a/src/app/components/MatchItem/MatchItem.examples.tsx
+++ b/src/app/components/MatchItem/MatchItem.examples.tsx
@@ -19,7 +19,7 @@ export const MatchItems: Example = () => (
         highlights: [
           {
             timestamp: 10,
-            type: ['kill'],
+            events: ['kill'],
             videoSrc: 'https://example.com/video.mp4',
           },
         ],

--- a/src/lib/matches.ts
+++ b/src/lib/matches.ts
@@ -44,7 +44,7 @@ export function ensureMatchesSchema(): Promise<Document> {
                 timestamp: {
                   bsonType: 'int',
                 },
-                type: {
+                events: {
                   bsonType: 'array',
                   items: {
                     bsonType: 'string',

--- a/src/lib/matches.ts
+++ b/src/lib/matches.ts
@@ -45,7 +45,10 @@ export function ensureMatchesSchema(): Promise<Document> {
                   bsonType: 'int',
                 },
                 type: {
-                  bsonType: 'string',
+                  bsonType: 'array',
+                  items: {
+                    bsonType: 'string',
+                  },
                 },
                 videoSrc: {
                   bsonType: 'string',

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -46,7 +46,8 @@ router.post('/matches/:matchId/highlights', async (request, response, next) => {
     const matchIdIsInvalid = !ObjectId.isValid(matchId);
     const requestIsInvalid =
       typeof timestamp !== 'number' ||
-      typeof type !== 'string' ||
+      !Array.isArray(type) ||
+      !type.every((item) => typeof item === 'string') ||
       typeof videoSrc !== 'string';
 
     if (matchIdIsInvalid) {

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -41,13 +41,13 @@ router.post('/matches', async (request, response, next) => {
 
 router.post('/matches/:matchId/highlights', async (request, response, next) => {
   try {
-    const { timestamp, type, videoSrc } = request.body;
+    const { timestamp, events, videoSrc } = request.body;
     const { matchId } = request.params;
     const matchIdIsInvalid = !ObjectId.isValid(matchId);
     const requestIsInvalid =
       typeof timestamp !== 'number' ||
-      !Array.isArray(type) ||
-      !type.every((item) => typeof item === 'string') ||
+      !Array.isArray(events) ||
+      !events.every((event) => typeof event === 'string') ||
       typeof videoSrc !== 'string';
 
     if (matchIdIsInvalid) {
@@ -62,7 +62,7 @@ router.post('/matches/:matchId/highlights', async (request, response, next) => {
 
     const highlight: MatchHighlight = {
       timestamp,
-      type,
+      events,
       videoSrc,
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import type { ObjectId } from 'mongodb';
 
 export type MatchHighlight = {
   timestamp: number;
-  type: string;
+  type: string[];
   videoSrc: string;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import type { ObjectId } from 'mongodb';
 
 export type MatchHighlight = {
   timestamp: number;
-  type: string[];
+  events: string[];
   videoSrc: string;
 };
 


### PR DESCRIPTION
Solves #40 

# 💥 Breaking Changes
As @lmachens mentioned these changes require to reset our database matches.

## Done
- Transform type of match highlights `type` from string into an array of strings
- Apply changes to the mongodb schema validation
- Apply changes in the serverside validation
- Apply changes to the depending components on client side
- Rename `type` into `events` for a better unterstanding
