### PR TITLE
🚑 Remove block_top_window_navigation

### DIFF
--- a/dist/overwolf/manifest.json
+++ b/dist/overwolf/manifest.json
@@ -23,7 +23,6 @@
         "is_background_page": true
       },
       "desktop": {
-        "block_top_window_navigation": true,
         "popup_blocker": true,
         "mute": true,
         "file": "build/index.html",


### PR DESCRIPTION
It is incompatible with debug_url. The desktop window does not open.
I added this issue to the existing `debug_url` discussion:
https://discuss.overwolf.com/t/no-file-system-access-with-debug-url-and-reload-issue/1911/7?u=lmachens

About `block_top_window_navigation`:
https://overwolf.github.io/docs/topics/windows-tips#use-block_top_window_navigation