### PR TITLE
🔨 Load development window only in DEBUG mode

### DIFF
--- a/src/app/background.tsx
+++ b/src/app/background.tsx
@@ -9,7 +9,10 @@ console.log('Starting background process');
 waitForOverwolf().then(async () => {
   startCaptureHighlights();
 
-  restoreWindow(WINDOWS.DEVELOPMENT);
+  if (localStorage.getItem('DEBUG') === 'true') {
+    restoreWindow(WINDOWS.DEVELOPMENT);
+  }
+
   restoreWindow(WINDOWS.DESKTOP);
 
   onAppLaunchTriggered(async () => {


### PR DESCRIPTION
Enable DEBUG by setting `DEBUG` to `true` in `localStorage`